### PR TITLE
provide a language attribute to the html doctype

### DIFF
--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html lang="en" html>
 <!--[if IE 7]>
   <html class="no-js ie7 oldie"<?php print $html_attributes; ?>>
 <![endif]-->


### PR DESCRIPTION
Language of page not set (SC 3.1.1 Level A)
https://www.w3.org/WAI/GL/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html
